### PR TITLE
Iterators within `Option`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -199,7 +199,8 @@ pub mod prelude {
         shortcuts::*,
         virtual_dom::{
             el_key, el_ref::el_ref, AsAtValue, At, AtValue, CSSValue, El, ElRef, Ev, EventHandler,
-            IntoNodes, Node, St, Tag, ToClasses, UpdateEl, UpdateElForIterator, View,
+            IntoNodes, Node, St, Tag, ToClasses, UpdateEl, UpdateElForIterator,
+            UpdateElForOptionIterator, View,
         },
     };
     pub use indexmap::IndexMap; // for attrs and style to work.

--- a/src/virtual_dom.rs
+++ b/src/virtual_dom.rs
@@ -17,7 +17,7 @@ pub use mailbox::Mailbox;
 pub use node::{el_key, El, ElKey, IntoNodes, Node, Text};
 pub use style::Style;
 pub use to_classes::ToClasses;
-pub use update_el::{UpdateEl, UpdateElForIterator};
+pub use update_el::{UpdateEl, UpdateElForIterator, UpdateElForOptionIterator};
 pub use values::{AsAtValue, AtValue, CSSValue};
 pub use view::View;
 

--- a/src/virtual_dom/update_el.rs
+++ b/src/virtual_dom/update_el.rs
@@ -14,6 +14,11 @@ pub trait UpdateElForIterator<Ms> {
     fn update_el(self, el: &mut El<Ms>);
 }
 
+/// Similar to `UpdateEl`, specialized for `Option<I> where I: Iterator`.
+pub trait UpdateElForOptionIterator<Ms> {
+    fn update_el_iter(self, el: &mut El<Ms>);
+}
+
 // ------ Implementations ------
 
 impl<Ms, T: UpdateEl<Ms> + Clone> UpdateEl<Ms> for &T {
@@ -131,6 +136,16 @@ impl<Ms, T: UpdateEl<Ms>, I: Iterator<Item = T>> UpdateElForIterator<Ms> for I {
     fn update_el(self, el: &mut El<Ms>) {
         for item in self {
             item.update_el(el);
+        }
+    }
+}
+
+impl<Ms, T: UpdateEl<Ms>, I: Iterator<Item = T>> UpdateElForOptionIterator<Ms> for Option<I> {
+    fn update_el_iter(self, el: &mut El<Ms>) {
+        if let Some(iter) = self {
+            for item in iter {
+                item.update_el(el);
+            }
         }
     }
 }

--- a/src/virtual_dom/update_el.rs
+++ b/src/virtual_dom/update_el.rs
@@ -16,7 +16,7 @@ pub trait UpdateElForIterator<Ms> {
 
 /// Similar to `UpdateEl`, specialized for `Option<I> where I: Iterator`.
 pub trait UpdateElForOptionIterator<Ms> {
-    fn update_el_iter(self, el: &mut El<Ms>);
+    fn update_el(self, el: &mut El<Ms>);
 }
 
 // ------ Implementations ------
@@ -141,7 +141,7 @@ impl<Ms, T: UpdateEl<Ms>, I: Iterator<Item = T>> UpdateElForIterator<Ms> for I {
 }
 
 impl<Ms, T: UpdateEl<Ms>, I: Iterator<Item = T>> UpdateElForOptionIterator<Ms> for Option<I> {
-    fn update_el_iter(self, el: &mut El<Ms>) {
+    fn update_el(self, el: &mut El<Ms>) {
         if let Some(iter) = self {
             for item in iter {
                 item.update_el(el);


### PR DESCRIPTION
Currently, a field within an element macro (e.g. `div!`) can either be a `Node<Msg>`, a `Option<Msg>`, or an `impl Iterator<Item = Node<Msg>`. This PR adds the last possibility; a `Option<impl Iterator<Item = Node<Msg>>`.